### PR TITLE
Implement the simulation method of Brettel et al.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ All the processing is done locally and the images do not leave your computer.
 This project is inspired by [Coblis - the Color BLIndness Simulator](http://www.color-blindness.com/coblis-color-blindness-simulator/).
 But instead of uploading the images to a server it does all the image processing locally in your webbrowser.
 
-You can choose between 2 different Simulation Algorithms *(Both are not proven to produce good or realistic results!)*:
+You can choose between 3 different Simulation Algorithms *(The first two are not proven to produce good or realistic results!)*:
 
 ##### The `ColorMatrix` Algorithm
 
@@ -36,3 +36,7 @@ From http://www.nofunc.com/Color_Blindness_Library/ [(web.archive)](http://web.a
     It is used with the permission of Matthew Wickline and HCIRN,
     and is freely available for non-commercial use. For commercial use, please
     contact the Human-Computer Interaction Resource Network ( http://hcirn.com/ ).
+
+##### The Brettel, Viénot and Mollon Simulation function
+
+This is an implementation of the research paper [_Computerized simulation of color appearance for dichromats_](http://vision.psychol.cam.ac.uk/jdmollon/papers/Dichromatsimulation.pdf) by Brettel, H., Viénot, F., & Mollon, J. D. (1997). It has been adapted to modern sRGB monitors and should be pretty accurate, at least for full dichromacy. Of course it is still an approximation though, many factors make it imperfect, such as uncalibrated monitor, unknown lighting environment, and per-individual variations. In general it will tend to be accurate for small or thin objects (small dots, lines) and too strong for large bright areas, even for full dichromats.

--- a/brettel_colorblind_simulation.js
+++ b/brettel_colorblind_simulation.js
@@ -1,0 +1,120 @@
+// Code adapted from libDaltonLens https://daltonlens.org (public domain)
+
+function linearRGB_from_sRGB(v)
+{
+    var fv = v / 255.0;
+    if (fv < 0.04045) return fv / 12.92;
+    return Math.pow((fv + 0.055) / 1.055, 2.4);
+}
+
+function sRGB_from_linearRGB(v)
+{
+    if (v <= 0.) return 0;
+    if (v >= 1.) return 255;
+    if (v < 0.0031308) return 0.5 + (v * 12.92 * 255);
+    return 0 + 255 * (Math.pow(v, 1.0 / 2.4) * 1.055 - 0.055);
+}
+
+var brettelFunctions = {
+    Normal: function (v) { return (v); },
+    Protanopia: function (v) { return brettel(v, 'protan', 1.0); },
+    Protanomaly: function (v) { return brettel(v, 'protan', 0.6); },
+    Deuteranopia: function (v) { return brettel(v, 'deutan', 1.0); },
+    Deuteranomaly: function (v) { return brettel(v, 'deutan', 0.6); },
+    Tritanopia: function (v) { return brettel(v, 'tritan', 1.0); },
+    Tritanomaly: function (v) { return brettel(v, 'tritan', 0.6); },
+    Achromatopsia: function (v) { return monochrome_with_severity(v, 1.0); },
+    Achromatomaly: function (v) { return monochrome_with_severity(v, 0.6); }
+};
+
+var sRGB_to_linearRGB_Lookup = Array(256);
+(function () {
+    var i;
+    for (i = 0; i < 256; i++) {
+        sRGB_to_linearRGB_Lookup[i] = linearRGB_from_sRGB(i);
+    }
+
+})();
+
+var LMS_from_linearRGB = Array(
+    0.17886, 0.43997, 0.03597,
+    0.03380, 0.27515, 0.03621,
+    0.00031, 0.00192, 0.01528
+);
+
+var linearRGB_from_LMS = Array(
+    8.00533, -12.88195, 11.68065,
+    -0.97821, 5.26945, -10.18300,
+    -0.04017, -0.39885, 66.48079
+);
+
+brettel_params = {
+    protan: {
+        lmsElementToProject: 0, // only this LMS coordinate is affected for protan
+        projectionOnPlane1: [0.00000, 2.18394, -5.65554],
+        projectionOnPlane2: [0.00000, 2.16614, -5.30455],
+        separationPlaneNormal: [0.00000, 0.01751, -0.34516]
+    },
+
+    deutan: {
+        lmsElementToProject: 1, // only this LMS coordinate is affected for protan
+        projectionOnPlane1: [0.46165, 0.00000, 2.44885],
+        projectionOnPlane2: [0.45789, 0.00000, 2.58960],
+        separationPlaneNormal: [-0.01751, 0.00000, 0.65480]
+    },
+
+    tritan: {
+        lmsElementToProject: 2, // only this LMS coordinate is affected for protan
+        projectionOnPlane1: [-0.00213, 0.05477, 0.00000],
+        projectionOnPlane2: [-0.06195, 0.16826, 0.00000],
+        separationPlaneNormal: [0.34516, -0.65480, 0.00000]
+    },
+};
+
+
+function brettel(srgb, t, severity) {
+    // Go from sRGB to linearRGB
+    var rgb = Array(3);
+    rgb[0] = sRGB_to_linearRGB_Lookup[srgb[0]]
+    rgb[1] = sRGB_to_linearRGB_Lookup[srgb[1]]
+    rgb[2] = sRGB_to_linearRGB_Lookup[srgb[2]]
+    
+    // lms = LMS_from_linearRGB * rgb
+    var lms = Array(3);
+    lms[0] = LMS_from_linearRGB[0]*rgb[0] + LMS_from_linearRGB[1]*rgb[1] + LMS_from_linearRGB[2]*rgb[2];
+    lms[1] = LMS_from_linearRGB[3]*rgb[0] + LMS_from_linearRGB[4]*rgb[1] + LMS_from_linearRGB[5]*rgb[2];
+    lms[2] = LMS_from_linearRGB[6]*rgb[0] + LMS_from_linearRGB[7]*rgb[1] + LMS_from_linearRGB[8]*rgb[2];
+
+    var params = brettel_params[t];
+    var separationPlaneNormal = params['separationPlaneNormal'];
+    var projectionOnPlane1 = params['projectionOnPlane1'];
+    var projectionOnPlane2 = params['projectionOnPlane2'];
+    var lmsElementToProject = params['lmsElementToProject'];
+
+    // Check on which plane we should project by comparing wih the separation plane normal.
+    var dotWithSepPlane = lms[0]*separationPlaneNormal[0] + lms[1]*separationPlaneNormal[1] + lms[2]*separationPlaneNormal[2];
+    var projectionOnPlane = (dotWithSepPlane >= 0 ? projectionOnPlane1 : projectionOnPlane2);
+
+    // Project on the plane. Only one coordinate changes (the axis corresponding
+    // to the missing cone cells), so no need to perform a full 3x3 multiplication.
+    // The severity factor is implemented as a linear interpolation with the original value.
+    var projected_element = projectionOnPlane[0]*lms[0] + projectionOnPlane[1]*lms[1] + projectionOnPlane[2]*lms[2];
+    lms[lmsElementToProject] = (projected_element*severity) + (lms[lmsElementToProject]*(1.0-severity));
+
+    // Go back to linear RGB
+    // rgb_cvd = linearRGB_from_LMS * lms
+    rgb[0] = linearRGB_from_LMS[0]*lms[0] + linearRGB_from_LMS[1]*lms[1] + linearRGB_from_LMS[2]*lms[2];    
+    rgb[1] = linearRGB_from_LMS[3]*lms[0] + linearRGB_from_LMS[4]*lms[1] + linearRGB_from_LMS[5]*lms[2];
+    rgb[2] = linearRGB_from_LMS[6]*lms[0] + linearRGB_from_LMS[7]*lms[1] + linearRGB_from_LMS[8]*lms[2];
+
+    return ([sRGB_from_linearRGB(rgb[0]),sRGB_from_linearRGB(rgb[1]),sRGB_from_linearRGB(rgb[2])]);
+}
+
+// Adjusted from the hcirn code
+function monochrome_with_severity(srgb, severity) {
+    var z = Math.round(srgb[0] * 0.299 + srgb[1] * 0.587 + srgb[2] * 0.114);
+    var r = z*severity + (1.0-severity)*srgb[0];
+    var g = z*severity + (1.0-severity)*srgb[1];
+    var b = z*severity + (1.0-severity)*srgb[2];
+    return ([r,g,b]);
+}

--- a/colorblind.js
+++ b/colorblind.js
@@ -85,7 +85,7 @@ function getFilteredImage(img, type, callback) {
     if (type in imageCache) {
         callback(imageCache[type], urlCache[type]);
     } else {
-        if (type === 'hcirnNormal' || type === 'simplNormal') {
+        if (type === 'hcirnNormal' || type === 'simplNormal' || type === 'brettNormal') {
             imageCache[type] = img;
             urlCache[type] = '#';
             callback(img, '#');
@@ -149,6 +149,8 @@ function getFilterFunction(type) {
         lib = fBlind;
     } else if (type.substring(0, 5) === 'simpl') {
         lib = colorMatrixFilterFunctions;
+    } else if (type.substring(0, 5) === 'brett') {
+        lib = brettelFunctions;
     } else {
         throw 'Invalid Filter Type!';
     }

--- a/index.html
+++ b/index.html
@@ -90,7 +90,11 @@ contact the Human-Computer Interaction Resource Network ( http://hcirn.com/ ).
 <label><input type="radio" name="colorblindType" value="Achromatopsia"/>Achromatopsia</label>
 <label><input type="radio" name="colorblindType" value="Achromatomaly"/>Achromatomaly</label>
 
-<label><input type="checkbox" name="hcirn" value="true" id="usehcirn">Use non-commercial-only algorithm</label>
+<select id="method">
+    <option value="simpl">Simple (ColorMatrix)</option>
+    <option value="hcirn">Non-commercial-only (HCIRN)</option>
+    <option value="brett">Accurate (Brettel et al.) </option>
+</select>
 <br/>
 <label><input type="radio" name="lens" value="No" checked/>No Lens</label>
 <label><input type="radio" name="lens" value="Normal"/>Normal Lens</label>
@@ -108,15 +112,17 @@ contact the Human-Computer Interaction Resource Network ( http://hcirn.com/ ).
             </div>
         </div>
         <script src="panZoomImage.js"></script>
+        <script src="brettel_colorblind_simulation.js"></script>
         <script src="hcirn_colorblind_simulation.js"></script>
         <script src="colorblind.js"></script>
         <script type="text/javascript">
 
 var loadingIndicator = document.getElementById('loadingIndicator');
 function filterOrImageChanged() {
+    
     var type = document.querySelector('input[name = "colorblindType"]:checked').value;
-    var usehcirn = document.getElementById("usehcirn").checked;
-    var filterName = (usehcirn ? "hcirn" : "simpl") + type;
+    var method = document.querySelector('#method option:checked').value;
+    var filterName = method + type;
     console.log("filterOrImageChanged: " + filterName);
 
     document.getElementById('imageLink').style.display = type === "Normal" ? "none" : "inline";
@@ -158,7 +164,7 @@ function lensChanged() {
     for (i = 0; i < radios.length; i++) {
         radios[i].onclick = lensChanged;
     }
-    document.getElementById("usehcirn").onclick = filterOrImageChanged;
+    document.getElementById("method").onchange = filterOrImageChanged;
 })();
 
 //Based on http://stackoverflow.com/a/3814285/2256700

--- a/index.html
+++ b/index.html
@@ -56,8 +56,9 @@
 <ul>
     <li><a href="http://web.archive.org/web/20081014161121/http://www.colorjack.com/labs/colormatrix/" target="blank">http://www.colorjack.com/labs/colormatrix/</a> (web.archive link, because original source is gone)</li>
     <li><a href="http://web.archive.org/web/20090318054431/http://www.nofunc.com/Color_Blindness_Library" target="blank">http://www.nofunc.com/Color_Blindness_Library</a> (web.archive link, because original source is gone)</li>
+    <li><a href="https://daltonlens.org#libdaltonlens" target="blank">libDaltonLens</a> (implementation of <a href="http://vision.psychol.cam.ac.uk/jdmollon/papers/Dichromatsimulation.pdf"><i>Computerized simulation of color appearance for dichromats</i></a> by Brettel et al.)</li>
 </ul>
-<h3>No guarantees that these are actually good!</h3>
+<h3>The first two algorithms have not been proven to be accurate.</h3>
 <a href="http://kaioa.com/node/75#comment-247" target="blank">Comment</a> about the first algorithm:
 <blockquote>
 <p>You're right, the ColorMatrix version is very simplified, and not accurate. I created that color matrix one night (<a href="http://www.colorjack.com/labs/colormatrix/" target="blank">http://www.colorjack.com/labs/colormatrix/</a>) and since then it's shown up many places... I should probably take that page down before it spreads more! Anyways, it gives you an idea of what it might look like, but for the real thing...</p>
@@ -76,6 +77,12 @@ It is used with the permission of Matthew Wickline and HCIRN,
 and is freely available for non-commercial use. For commercial use, please
 contact the Human-Computer Interaction Resource Network ( http://hcirn.com/ ).
 </pre></blockquote>
+
+Comment about the third algorithm:
+<blockquote><p>
+The Brettel et al. method was published in 1997 in the age of CRT monitors and has been adapted to modern sRGB monitors. It should be pretty accurate, at least for full dichromacy. Of course it is still an approximation and many factors make it imperfect, including an uncalibrated monitor, unknown lighting environment, and per-individual variations. In general it will tend to be accurate for small or thin objects (small dots, lines) and too strong for large bright areas, even for full dichromats.
+</p></blockquote>
+
         </div>
         <div class="container" style="">
             <div>


### PR DESCRIPTION
Hi, I recently reviewed the available CVD simulation methods and came to the conclusion that the HCIRN function is quite inaccurate, and that a much more solid one is  [_Computerized simulation of color appearance for dichromats_](http://vision.psychol.cam.ac.uk/jdmollon/papers/Dichromatsimulation.pdf) by Brettel, Viénot and Mollon (1997).

It is for example used as a reference by more recent papers such as [A physiologically-based model for simulation of color vision deficiency](https://www.lume.ufrgs.br/bitstream/handle/10183/27630/000751721.pdf) by Machado et al, or [Using a behavioral match-to-sample method to evaluate color vision deficiency simulation methods
](https://folk.ntnu.no/ivarfa/publications/journal/Simon_16_jist.pdf).

Besides my own protan vision, this seems to be confirmed by [an informal evaluation on r/colorblind reddit](https://www.reddit.com/r/ColorBlind/comments/qzkl7h/lets_collectively_determine_the_best_color/) where the Brettel method (and Viénot, which is an approximation for protanopia and deuteranopia) are generally the most convincing ones.

For more details I wrote a full [Review of Open Source Color Blindness Simulations](https://daltonlens.org/opensource-cvd-simulation/) to discuss the various approaches and an [online comparison of the methods](https://daltonlens.org/colorblindness-simulator).

In any case this PR implements the Brettel et al. method and I hope that it can become the default on Coblis as it's the most popular online CVD simulator. Hope this helps!